### PR TITLE
Increase Windows accessibility AMI build resilience

### DIFF
--- a/.github/workflows/build-windows-a11y-ami.yml
+++ b/.github/workflows/build-windows-a11y-ami.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Install/update Chrome, Firefox, NVDA
         id: software
         run: |
-          OUTPUT=$(bash scripts/windows-a11y/ssm-run.sh "${{ steps.launch.outputs.instance_id }}" scripts/windows-a11y/install-software.ps1 1800 | tr -d '\r')
+          OUTPUT=$(bash scripts/windows-a11y/ssm-run.sh "${{ steps.launch.outputs.instance_id }}" scripts/windows-a11y/install-software.ps1 7200 | tr -d '\r')
           echo "${OUTPUT}"
           echo "chrome_version=$(echo "${OUTPUT}" | grep -oP 'VERSION_GOOGLECHROME=\K.*')" >> "$GITHUB_OUTPUT"
           echo "firefox_version=$(echo "${OUTPUT}" | grep -oP 'VERSION_FIREFOX=\K.*')" >> "$GITHUB_OUTPUT"
@@ -97,7 +97,7 @@ jobs:
 
       - name: Configure RDP and display language
         run: |
-          bash scripts/windows-a11y/ssm-run.sh "${{ steps.launch.outputs.instance_id }}" scripts/windows-a11y/configure-system.ps1 900
+          bash scripts/windows-a11y/ssm-run.sh "${{ steps.launch.outputs.instance_id }}" scripts/windows-a11y/configure-system.ps1 3600
           aws ec2 reboot-instances --instance-ids "${{ steps.launch.outputs.instance_id }}"
           sleep 30
           aws ec2 wait instance-status-ok --instance-ids "${{ steps.launch.outputs.instance_id }}"

--- a/scripts/windows-a11y/install-software.ps1
+++ b/scripts/windows-a11y/install-software.ps1
@@ -12,17 +12,46 @@ if (-not (Get-Command choco -ErrorAction SilentlyContinue)) {
     $env:Path = "$env:Path;C:\ProgramData\chocolatey\bin"
 }
 
+$chocoPath = (Get-Command choco -ErrorAction Stop).Source
+$successfulExitCodes = @(0, 2, 1641, 3010)
+
+function Install-OrUpgradePackage {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Package,
+
+        [int]$MaxAttempts = 3
+    )
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        Write-Output "$logPrefix Installing/updating $Package (attempt $attempt of $MaxAttempts)..."
+
+        # Do not discard Chocolatey's output: it contains the installer-specific
+        # error that is needed to diagnose failures from the SSM command log.
+        & $chocoPath upgrade $Package -y --no-progress --execution-timeout=1200 --ignore-detected-reboot
+        $exitCode = $LASTEXITCODE
+
+        if ($exitCode -in $successfulExitCodes) {
+            return
+        }
+
+        if ($attempt -lt $MaxAttempts) {
+            $retryDelay = 15 * $attempt
+            Write-Warning "$logPrefix choco upgrade $Package failed with exit code $exitCode; retrying in $retryDelay seconds."
+            Start-Sleep -Seconds $retryDelay
+        }
+    }
+
+    throw "$logPrefix choco upgrade $Package failed after $MaxAttempts attempts (last exit code: $exitCode)"
+}
+
 $packages = @('googlechrome', 'firefox', 'nvda')
 foreach ($package in $packages) {
-    Write-Output "$logPrefix Installing/updating $package..."
-    choco upgrade $package -y --no-progress | Out-Null
-    if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 3010) {
-        throw "$logPrefix choco upgrade $package failed with exit code $LASTEXITCODE"
-    }
+    Install-OrUpgradePackage -Package $package
 }
 
 Write-Output "$logPrefix Installed package versions:"
-$versionLines = @(choco list --limit-output |
+$versionLines = @(& $chocoPath list --limit-output |
     Where-Object { $_ -match '^(googlechrome|firefox|nvda)\|' })
 if ($versionLines.Count -lt $packages.Count) {
     throw "$logPrefix Expected $($packages.Count) installed package versions but found $($versionLines.Count): $($versionLines -join '; ')"


### PR DESCRIPTION
## Summary
- Extend SSM command timeouts for Windows software installation and system configuration.
- Add Chocolatey retries, installer-specific output, execution timeouts, and accepted reboot exit codes.
- Validate package versions using the resolved Chocolatey executable.

## Testing
- Not run (not requested)