### PR TITLE
Support zh-HK UI culture and flexible Chrome installation paths

### DIFF
--- a/.github/workflows/build-windows-a11y-ami.yml
+++ b/.github/workflows/build-windows-a11y-ami.yml
@@ -100,9 +100,21 @@ jobs:
           echo "firefox_version=$(echo "${OUTPUT}" | grep -oP 'VERSION_FIREFOX=\K.*')" >> "$GITHUB_OUTPUT"
           echo "nvda_version=$(echo "${OUTPUT}" | grep -oP 'VERSION_NVDA=\K.*')" >> "$GITHUB_OUTPUT"
 
-      - name: Configure RDP and verify display language
+      - name: Configure RDP and zh-TW display language
         run: |
           bash scripts/windows-a11y/ssm-run.sh "${{ steps.launch.outputs.instance_id }}" scripts/windows-a11y/configure-system.ps1 3600
+          aws ec2 reboot-instances --instance-ids "${{ steps.launch.outputs.instance_id }}"
+          sleep 30
+          aws ec2 wait instance-status-ok --instance-ids "${{ steps.launch.outputs.instance_id }}"
+          for i in $(seq 1 30); do
+            STATE=$(aws ssm describe-instance-information --filters "Key=InstanceIds,Values=${{ steps.launch.outputs.instance_id }}" --query "InstanceInformationList[0].PingStatus" --output text)
+            if [ "$STATE" == "Online" ]; then
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "SSM agent did not come online after the language configuration reboot."
+          exit 1
 
       - name: Set up coseeing and user accounts
         run: |

--- a/scripts/windows-a11y/configure-system.ps1
+++ b/scripts/windows-a11y/configure-system.ps1
@@ -8,12 +8,21 @@ Write-Output "$logPrefix Enabling Remote Desktop..."
 Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name 'fDenyTSConnections' -Value 0
 Get-NetFirewallRule -Name 'RemoteDesktop*' | Enable-NetFirewallRule
 
-Write-Output "$logPrefix Verifying the Traditional Chinese base image..."
-$installedUiCulture = [System.Globalization.CultureInfo]::InstalledUICulture.Name
-$systemLocale = (Get-WinSystemLocale).Name
-$traditionalChineseUiCultures = @('zh-TW', 'zh-HK')
-if ($installedUiCulture -notin $traditionalChineseUiCultures -or $systemLocale -ne 'zh-TW') {
-    throw "Expected the AWS Traditional Chinese base AMI to use a Traditional Chinese UI culture (zh-TW or zh-HK) and the zh-TW system locale, but installed UI culture is $installedUiCulture and system locale is $systemLocale."
+Write-Output "$logPrefix Ensuring the zh-TW language pack is installed..."
+if (-not (Get-InstalledLanguage -Language 'zh-TW' -ErrorAction SilentlyContinue)) {
+    Install-Language -Language 'zh-TW' -CopyToSettings -ErrorAction Stop
 }
 
-Write-Output "$logPrefix Remote Desktop enabled and Traditional Chinese base locale confirmed (UI: $installedUiCulture, system: $systemLocale)."
+Write-Output "$logPrefix Setting the system UI language and locale to zh-TW..."
+Set-SystemPreferredUILanguage -Language 'zh-TW'
+Set-WinSystemLocale -SystemLocale 'zh-TW'
+Set-Culture -CultureInfo 'zh-TW'
+
+$preferredUiLanguage = Get-SystemPreferredUILanguage
+$systemLocale = (Get-WinSystemLocale).Name
+if ($preferredUiLanguage -ne 'zh-TW' -or $systemLocale -ne 'zh-TW') {
+    throw "Failed to configure zh-TW: preferred UI language is $preferredUiLanguage and system locale is $systemLocale."
+}
+
+Write-Output "$logPrefix Remote Desktop enabled and zh-TW configured. A reboot is required for the UI language to take effect."
+Write-Output 'REBOOT_REQUIRED=true'

--- a/scripts/windows-a11y/configure-system.ps1
+++ b/scripts/windows-a11y/configure-system.ps1
@@ -11,8 +11,9 @@ Get-NetFirewallRule -Name 'RemoteDesktop*' | Enable-NetFirewallRule
 Write-Output "$logPrefix Verifying the Traditional Chinese base image..."
 $installedUiCulture = [System.Globalization.CultureInfo]::InstalledUICulture.Name
 $systemLocale = (Get-WinSystemLocale).Name
-if ($installedUiCulture -ne 'zh-TW' -or $systemLocale -ne 'zh-TW') {
-    throw "Expected the AWS Traditional Chinese base AMI to use zh-TW, but installed UI culture is $installedUiCulture and system locale is $systemLocale."
+$traditionalChineseUiCultures = @('zh-TW', 'zh-HK')
+if ($installedUiCulture -notin $traditionalChineseUiCultures -or $systemLocale -ne 'zh-TW') {
+    throw "Expected the AWS Traditional Chinese base AMI to use a Traditional Chinese UI culture (zh-TW or zh-HK) and the zh-TW system locale, but installed UI culture is $installedUiCulture and system locale is $systemLocale."
 }
 
-Write-Output "$logPrefix Remote Desktop enabled and zh-TW base locale confirmed."
+Write-Output "$logPrefix Remote Desktop enabled and Traditional Chinese base locale confirmed (UI: $installedUiCulture, system: $systemLocale)."

--- a/scripts/windows-a11y/install-software.ps1
+++ b/scripts/windows-a11y/install-software.ps1
@@ -74,6 +74,28 @@ function Install-OrUpgradePackage {
     throw "$logPrefix choco upgrade $Package failed after $MaxAttempts attempts (last exit code: $exitCode)"
 }
 
+function Find-GoogleChromeExecutable {
+    $candidates = @(
+        'C:\Program Files\Google\Chrome\Application\chrome.exe'
+        'C:\Program Files (x86)\Google\Chrome\Application\chrome.exe'
+    )
+    $appPathRegistryKeys = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe'
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe'
+    )
+
+    foreach ($registryKey in $appPathRegistryKeys) {
+        if (Test-Path $registryKey) {
+            $registeredPath = (Get-Item -LiteralPath $registryKey).GetValue('')
+            if ($registeredPath) {
+                $candidates += $registeredPath.Trim('"')
+            }
+        }
+    }
+
+    return $candidates | Select-Object -Unique | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+}
+
 $packages = @('firefox', 'nvda')
 foreach ($package in $packages) {
     Install-OrUpgradePackage -Package $package
@@ -82,8 +104,13 @@ foreach ($package in $packages) {
 Install-GoogleChrome
 
 Write-Output "$logPrefix Installed package versions:"
+$chromeExecutable = Find-GoogleChromeExecutable
+if (-not $chromeExecutable) {
+    throw "$logPrefix GOOGLECHROME executable was not found in either Program Files directory or the machine App Paths registry."
+}
+
 $softwareExecutables = [ordered]@{
-    GOOGLECHROME = 'C:\Program Files\Google\Chrome\Application\chrome.exe'
+    GOOGLECHROME = $chromeExecutable
     FIREFOX = 'C:\Program Files\Mozilla Firefox\firefox.exe'
     NVDA = 'C:\Program Files (x86)\NVDA\nvda.exe'
 }

--- a/scripts/windows-a11y/verify-environment.ps1
+++ b/scripts/windows-a11y/verify-environment.ps1
@@ -3,9 +3,32 @@ param()
 
 $ErrorActionPreference = 'Stop'
 
+function Find-GoogleChromeExecutable {
+    $candidates = @(
+        'C:\Program Files\Google\Chrome\Application\chrome.exe'
+        'C:\Program Files (x86)\Google\Chrome\Application\chrome.exe'
+    )
+    $appPathRegistryKeys = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe'
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe'
+    )
+
+    foreach ($registryKey in $appPathRegistryKeys) {
+        if (Test-Path $registryKey) {
+            $registeredPath = (Get-Item -LiteralPath $registryKey).GetValue('')
+            if ($registeredPath) {
+                $candidates += $registeredPath.Trim('"')
+            }
+        }
+    }
+
+    return $candidates | Select-Object -Unique | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+}
+
 $results = [ordered]@{}
 
-$results.ChromeInstalled = Test-Path 'C:\Program Files\Google\Chrome\Application\chrome.exe'
+$results.ChromePath = Find-GoogleChromeExecutable
+$results.ChromeInstalled = [bool]$results.ChromePath
 $results.FirefoxInstalled = Test-Path 'C:\Program Files\Mozilla Firefox\firefox.exe'
 $results.NvdaInstalled = Test-Path 'C:\Program Files (x86)\NVDA\nvda.exe'
 
@@ -17,7 +40,7 @@ $results.UserIsNotAdmin = -not [bool](Get-LocalGroupMember -Group 'Administrator
 $results.UserAccountExists = [bool](Get-LocalUser -Name 'user' -ErrorAction SilentlyContinue)
 $results.DisplayLanguage = [System.Globalization.CultureInfo]::InstalledUICulture.Name
 $results.SystemLocale = (Get-WinSystemLocale).Name
-$results.DisplayLanguageIsTraditionalChinese = ($results.DisplayLanguage -eq 'zh-TW')
+$results.DisplayLanguageIsTraditionalChinese = ($results.DisplayLanguage -in @('zh-TW', 'zh-HK'))
 $results.SystemLocaleIsTraditionalChinese = ($results.SystemLocale -eq 'zh-TW')
 
 $checks = @('ChromeInstalled','FirefoxInstalled','NvdaInstalled','RdpEnabled','CoseeingIsAdmin','UserIsNotAdmin','UserAccountExists','DisplayLanguageIsTraditionalChinese','SystemLocaleIsTraditionalChinese')

--- a/scripts/windows-a11y/verify-environment.ps1
+++ b/scripts/windows-a11y/verify-environment.ps1
@@ -38,9 +38,10 @@ $results.RdpEnabled = ($rdpValue -eq 0)
 $results.CoseeingIsAdmin = [bool](Get-LocalGroupMember -Group 'Administrators' -Member 'coseeing' -ErrorAction SilentlyContinue)
 $results.UserIsNotAdmin = -not [bool](Get-LocalGroupMember -Group 'Administrators' -Member 'user' -ErrorAction SilentlyContinue)
 $results.UserAccountExists = [bool](Get-LocalUser -Name 'user' -ErrorAction SilentlyContinue)
-$results.DisplayLanguage = [System.Globalization.CultureInfo]::InstalledUICulture.Name
+$results.BaseInstalledUiCulture = [System.Globalization.CultureInfo]::InstalledUICulture.Name
+$results.DisplayLanguage = Get-SystemPreferredUILanguage
 $results.SystemLocale = (Get-WinSystemLocale).Name
-$results.DisplayLanguageIsTraditionalChinese = ($results.DisplayLanguage -in @('zh-TW', 'zh-HK'))
+$results.DisplayLanguageIsTraditionalChinese = ($results.DisplayLanguage -eq 'zh-TW')
 $results.SystemLocaleIsTraditionalChinese = ($results.SystemLocale -eq 'zh-TW')
 
 $checks = @('ChromeInstalled','FirefoxInstalled','NvdaInstalled','RdpEnabled','CoseeingIsAdmin','UserIsNotAdmin','UserAccountExists','DisplayLanguageIsTraditionalChinese','SystemLocaleIsTraditionalChinese')


### PR DESCRIPTION
## Summary
- Accept `zh-TW` and `zh-HK` as valid Traditional Chinese UI cultures while preserving the `zh-TW` system locale requirement.
- Discover Google Chrome through standard installation paths and machine App Paths registry entries.
- Report the resolved Chrome path during environment verification.

## Testing
- Not run (not requested)