### PR TITLE
Harden Windows accessibility setup and MSI installation handling

### DIFF
--- a/scripts/windows-a11y/configure-system.ps1
+++ b/scripts/windows-a11y/configure-system.ps1
@@ -20,7 +20,8 @@ Set-Culture -CultureInfo 'zh-TW'
 
 $preferredUiLanguage = Get-SystemPreferredUILanguage
 $systemLocale = (Get-WinSystemLocale).Name
-if ($preferredUiLanguage -ne 'zh-TW' -or $systemLocale -ne 'zh-TW') {
+$traditionalChineseTaiwanLanguages = @('zh-TW', 'zh-Hant-TW')
+if ($preferredUiLanguage -notin $traditionalChineseTaiwanLanguages -or $systemLocale -ne 'zh-TW') {
     throw "Failed to configure zh-TW: preferred UI language is $preferredUiLanguage and system locale is $systemLocale."
 }
 

--- a/scripts/windows-a11y/install-software.ps1
+++ b/scripts/windows-a11y/install-software.ps1
@@ -19,6 +19,7 @@ function Install-GoogleChrome {
     $installerUri = 'https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi'
     $downloadDirectory = Join-Path $env:TEMP 'windows-a11y-installers'
     $installerPath = Join-Path $downloadDirectory 'googlechromestandaloneenterprise64.msi'
+    $installerLogPath = Join-Path $downloadDirectory 'googlechrome-install.log'
 
     New-Item -ItemType Directory -Path $downloadDirectory -Force | Out-Null
 
@@ -35,10 +36,21 @@ function Install-GoogleChrome {
     }
 
     Write-Output "$logPrefix Installing/updating Google Chrome (verified publisher: $publisher)..."
-    & msiexec.exe /i $installerPath /qn /norestart
-    $exitCode = $LASTEXITCODE
+    # Start-Process avoids sending msiexec's UTF-16 output through SSM and, with
+    # -Wait, does not let executable verification race the installer service.
+    $installerArguments = @(
+        '/i'
+        "`"$installerPath`""
+        '/qn'
+        '/norestart'
+        '/L*v'
+        "`"$installerLogPath`""
+    )
+    $installerProcess = Start-Process -FilePath "$env:SystemRoot\System32\msiexec.exe" -ArgumentList $installerArguments -Wait -PassThru
+    $exitCode = $installerProcess.ExitCode
     if ($exitCode -notin @(0, 1641, 3010)) {
-        throw "$logPrefix Google Chrome MSI installation failed with exit code $exitCode"
+        $logTail = (Get-Content -LiteralPath $installerLogPath -Tail 40 -ErrorAction SilentlyContinue) -join [Environment]::NewLine
+        throw "$logPrefix Google Chrome MSI installation failed with exit code $exitCode.`n$logTail"
     }
 
     Remove-Item -Path $installerPath -Force
@@ -96,6 +108,22 @@ function Find-GoogleChromeExecutable {
     return $candidates | Select-Object -Unique | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
 }
 
+function Wait-GoogleChromeExecutable {
+    param([int]$TimeoutSeconds = 60)
+
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    do {
+        $executable = Find-GoogleChromeExecutable
+        if ($executable) {
+            return $executable
+        }
+
+        Start-Sleep -Seconds 2
+    } while ($stopwatch.Elapsed.TotalSeconds -lt $TimeoutSeconds)
+
+    return $null
+}
+
 $packages = @('firefox', 'nvda')
 foreach ($package in $packages) {
     Install-OrUpgradePackage -Package $package
@@ -104,9 +132,11 @@ foreach ($package in $packages) {
 Install-GoogleChrome
 
 Write-Output "$logPrefix Installed package versions:"
-$chromeExecutable = Find-GoogleChromeExecutable
+$chromeExecutable = Wait-GoogleChromeExecutable
 if (-not $chromeExecutable) {
-    throw "$logPrefix GOOGLECHROME executable was not found in either Program Files directory or the machine App Paths registry."
+    $installerLogPath = Join-Path $env:TEMP 'windows-a11y-installers\googlechrome-install.log'
+    $logTail = (Get-Content -LiteralPath $installerLogPath -Tail 40 -ErrorAction SilentlyContinue) -join [Environment]::NewLine
+    throw "$logPrefix GOOGLECHROME executable was not found after waiting for the MSI installation to settle. MSI log: $installerLogPath`n$logTail"
 }
 
 $softwareExecutables = [ordered]@{

--- a/scripts/windows-a11y/ssm-run.sh
+++ b/scripts/windows-a11y/ssm-run.sh
@@ -90,13 +90,11 @@ STATUS=$(jq -r '.Status' <<< "${FINAL_INVOCATION}")
 STATUS_DETAILS=$(jq -r '.StatusDetails' <<< "${FINAL_INVOCATION}")
 EXECUTION_ELAPSED=$(jq -r '.ExecutionElapsedTime // "n/a"' <<< "${FINAL_INVOCATION}")
 RESPONSE_CODE=$(jq -r '.ResponseCode' <<< "${FINAL_INVOCATION}")
-STDOUT_CONTENT=$(jq -r '.StandardOutputContent // empty' <<< "${FINAL_INVOCATION}")
-STDERR_CONTENT=$(jq -r '.StandardErrorContent // empty' <<< "${FINAL_INVOCATION}")
 
-echo "${STDOUT_CONTENT}"
+jq -r '.StandardOutputContent // empty' <<< "${FINAL_INVOCATION}" | tr -d '\000'
 
 if [[ "${STATUS}" != "Success" ]]; then
   echo "SSM command ${COMMAND_ID} ended with status ${STATUS} (${STATUS_DETAILS}), response code ${RESPONSE_CODE}, elapsed ${EXECUTION_ELAPSED}" >&2
-  echo "${STDERR_CONTENT}" >&2
+  jq -r '.StandardErrorContent // empty' <<< "${FINAL_INVOCATION}" | tr -d '\000' >&2
   exit 1
 fi

--- a/scripts/windows-a11y/verify-environment.ps1
+++ b/scripts/windows-a11y/verify-environment.ps1
@@ -41,7 +41,7 @@ $results.UserAccountExists = [bool](Get-LocalUser -Name 'user' -ErrorAction Sile
 $results.BaseInstalledUiCulture = [System.Globalization.CultureInfo]::InstalledUICulture.Name
 $results.DisplayLanguage = Get-SystemPreferredUILanguage
 $results.SystemLocale = (Get-WinSystemLocale).Name
-$results.DisplayLanguageIsTraditionalChinese = ($results.DisplayLanguage -eq 'zh-TW')
+$results.DisplayLanguageIsTraditionalChinese = ($results.DisplayLanguage -in @('zh-TW', 'zh-Hant-TW'))
 $results.SystemLocaleIsTraditionalChinese = ($results.SystemLocale -eq 'zh-TW')
 
 $checks = @('ChromeInstalled','FirefoxInstalled','NvdaInstalled','RdpEnabled','CoseeingIsAdmin','UserIsNotAdmin','UserAccountExists','DisplayLanguageIsTraditionalChinese','SystemLocaleIsTraditionalChinese')


### PR DESCRIPTION
## Summary
- Accept `zh-Hant-TW` as a valid Traditional Chinese display language.
- Run Chrome MSI installation with logging and wait for the executable to become available.
- Improve SSM output handling by removing UTF-16 null bytes and preserving error diagnostics.

## Testing
- Not run (not requested)